### PR TITLE
fails with both "flatten" and "nothing" on fluentd 0.12.22

### DIFF
--- a/lib/fluent/plugin/parser_json_transform.rb
+++ b/lib/fluent/plugin/parser_json_transform.rb
@@ -21,6 +21,11 @@ module Fluent
         @transformer = JSONTransformer.new
       end
 
+      def call(text)
+        raw_json = JSON.parse(text)
+        return nil, @transformer.transform(raw_json)
+      end
+
       def parse(text)
         raw_json = JSON.parse(text)
         return nil, @transformer.transform(raw_json)

--- a/lib/fluent/plugin/parser_json_transform.rb
+++ b/lib/fluent/plugin/parser_json_transform.rb
@@ -1,6 +1,7 @@
 module Fluent
   class TextParser
     class JSONTransformParser
+      require 'json'
       DEFAULTS = [ 'nothing', 'flatten' ]
 
       include Configurable

--- a/lib/fluent/plugin/parser_json_transform.rb
+++ b/lib/fluent/plugin/parser_json_transform.rb
@@ -1,7 +1,6 @@
 module Fluent
   class TextParser
     class JSONTransformParser
-      require 'json'
       DEFAULTS = [ 'nothing', 'flatten' ]
 
       include Configurable
@@ -22,7 +21,7 @@ module Fluent
         @transformer = JSONTransformer.new
       end
 
-      def call(text)
+      def parse(text)
         raw_json = JSON.parse(text)
         return nil, @transformer.transform(raw_json)
       end


### PR DESCRIPTION
Updated the method being called to comply with TextParser updates.
